### PR TITLE
Fix dtype casting logic in `sageattn_varlen` for bf16/fp32 inputs

### DIFF
--- a/csrc/mma.cuh
+++ b/csrc/mma.cuh
@@ -153,67 +153,39 @@ __device__ __forceinline__ void mma_sync_m16n8k16_row_col_f16f16f32(float* C, ui
           "f"(0.f), "f"(0.f));
   }
 #else  // MMA_F16F16F32_M16N8K16_ENABLED
+  // SM75 optimization: Use single ASM block to allow ILP between the two MMA instructions.
+  // Although K-split implies dependency, keeping them in one block helps register allocation.
+  float t0, t1, t2, t3;
   if constexpr (mma_mode == MMAMode::kInplaceUpdate)
   {
-    // SM_75 fallback for InplaceUpdate
     asm volatile(
         "{\n"
-        ".reg .b32 tmp0, tmp1, tmp2, tmp3;\n" // Temp float registers for intermediate accumulation
-
-        // First m16n8k8: Processes first half of K dimension (k=0..7)
-        // Inputs: A[0], A[1] (holding first 4 f16s of A's K dim)
-        //         B[0]      (holding first 2 f16s of B's K dim)
-        // Accumulates from existing C values into temps
         "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
-        "{tmp0,  tmp1,  tmp2,  tmp3}," // Output to temps
-        "{%4,  %5},"                   // Input A registers {A[0], A[1]}
-        "{%8},"                        // Input B register {B[0]}
-        "{%10, %11, %12, %13};\n"      // Input C accumulators {C[0], C[1], C[2], C[3]}
-
-        // Second m16n8k8: Processes second half of K dimension (k=8..15)
-        // Inputs: A[2], A[3] (holding second 4 f16s of A's K dim)
-        //         B[1]      (holding second 2 f16s of B's K dim)
-        // Accumulates from temps into final C registers
+        "{%0,  %1,  %2,  %3}, {%8,  %9}, {%12}, {%14, %15, %16, %17};\n"
         "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
-        "{%0,  %1,  %2,  %3},"         // Output to final C registers {C[0], C[1], C[2], C[3]}
-        "{%6,  %7},"                   // Input A registers {A[2], A[3]}
-        "{%9},"                        // Input B register {B[1]}
-        "{tmp0,  tmp1,  tmp2,  tmp3};\n" // Input C accumulators (temps from previous step)
+        "{%4,  %5,  %6,  %7}, {%10, %11}, {%13}, {%0,  %1,  %2,  %3};\n"
         "}\n"
-        : "=f"(C[0]), "=f"(C[1]), "=f"(C[2]), "=f"(C[3])   // %0..3: Output registers (final C)
-        : "r"(A[0]), "r"(A[1]), "r"(A[2]), "r"(A[3]),     // %4..7: Input registers for A
-          "r"(B[0]), "r"(B[1]),                           // %8..9: Input registers for B
-          "f"(C[0]), "f"(C[1]), "f"(C[2]), "f"(C[3]));   // %10..13: Input registers for initial C (read-only)
+        : "=&f"(t0), "=&f"(t1), "=&f"(t2), "=&f"(t3),
+          "=f"(C[0]), "=f"(C[1]), "=f"(C[2]), "=f"(C[3])
+        : "r"(A[0]), "r"(A[1]), "r"(A[2]), "r"(A[3]),
+          "r"(B[0]), "r"(B[1]),
+          "f"(C[0]), "f"(C[1]), "f"(C[2]), "f"(C[3])
+    );
   }
   else if constexpr (mma_mode == MMAMode::kInit)
   {
-    // SM_75 fallback for Init
     asm volatile(
         "{\n"
-        ".reg .b32 tmp0, tmp1, tmp2, tmp3;\n" // Temp float registers
-
-        // First m16n8k8: Processes first half of K dimension (k=0..7)
-        // Inputs: A[0], A[1], B[0]
-        // Accumulates from 0.f into temps
         "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
-        "{tmp0,  tmp1,  tmp2,  tmp3}," // Output to temps
-        "{%4,  %5},"                   // Input A registers {A[0], A[1]}
-        "{%8},"                        // Input B register {B[0]}
-        "{%10, %11, %12, %13};\n"      // Input C accumulators {0.f, 0.f, 0.f, 0.f}
-
-        // Second m16n8k8: Processes second half of K dimension (k=8..15)
-        // Inputs: A[2], A[3], B[1]
-        // Accumulates from temps into final C registers
+        "{%0,  %1,  %2,  %3}, {%8,  %9}, {%12}, {0.0, 0.0, 0.0, 0.0};\n"
         "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
-        "{%0,  %1,  %2,  %3},"         // Output to final C registers {C[0], C[1], C[2], C[3]}
-        "{%6,  %7},"                   // Input A registers {A[2], A[3]}
-        "{%9},"                        // Input B register {B[1]}
-        "{tmp0,  tmp1,  tmp2,  tmp3};\n" // Input C accumulators (temps from previous step)
+        "{%4,  %5,  %6,  %7}, {%10, %11}, {%13}, {%0,  %1,  %2,  %3};\n"
         "}\n"
-        : "=f"(C[0]), "=f"(C[1]), "=f"(C[2]), "=f"(C[3])   // %0..3: Output registers (final C)
-        : "r"(A[0]), "r"(A[1]), "r"(A[2]), "r"(A[3]),     // %4..7: Input registers for A
-          "r"(B[0]), "r"(B[1]),                           // %8..9: Input registers for B
-          "f"(0.f), "f"(0.f), "f"(0.f), "f"(0.f));       // %10..13: Input registers for initial C (zeros)
+        : "=&f"(t0), "=&f"(t1), "=&f"(t2), "=&f"(t3),
+          "=f"(C[0]), "=f"(C[1]), "=f"(C[2]), "=f"(C[3])
+        : "r"(A[0]), "r"(A[1]), "r"(A[2]), "r"(A[3]),
+          "r"(B[0]), "r"(B[1])
+    );
   }
 #endif
 }
@@ -274,107 +246,49 @@ __device__ __forceinline__ void mma_sync_m16n16k16_row_col_f16f16f32(float* C, u
           "f"(0.f), "f"(0.f));
   }
 #else  // MMA_F16F16F32_M16N8K16_ENABLED
-  // Define temporary registers for the accumulator chaining
-  float t0, t1, t2, t3;
+  // SM75 optimization: Interleave Left and Right halves calculations to hide latency.
+  float t0, t1, t2, t3, t4, t5, t6, t7;
 
   if constexpr (mma_mode == MMAMode::kInplaceUpdate)
   {
-      // --- First m16n8k16 replacement (uses B[0], B[1]) ---
-      // First m16n8k8 step (K=0..7)
       asm volatile(
+          "{\n"
           "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
-          "{%0, %1, %2, %3}," // Temporaries
-          "{%4, %5},"          // A[0], A[1]
-          "{%6},"              // B[0]
-          "{%7, %8, %9, %10};" // C[0], C[1], C[2], C[3] initial
-          : "=f"(t0), "=f"(t1), "=f"(t2), "=f"(t3)
-          : "r"(A[0]), "r"(A[1]), "r"(B[0]),
-            "f"(C[0]), "f"(C[1]), "f"(C[2]), "f"(C[3])
-      );
-      // Second m16n8k8 step (K=8..15), accumulating into temps
-      asm volatile(
+          "{%0, %1, %2, %3}, {%8, %9}, {%12}, {%16, %17, %18, %19};\n"
           "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
-          "{%0, %1, %2, %3}," // C[0], C[1], C[2], C[3] final
-          "{%4, %5},"          // A[2], A[3]
-          "{%6},"              // B[1]
-          "{%7, %8, %9, %10};" // Temporaries from previous step
-          : "=f"(C[0]), "=f"(C[1]), "=f"(C[2]), "=f"(C[3])
-          : "r"(A[2]), "r"(A[3]), "r"(B[1]),
-            "f"(t0), "f"(t1), "f"(t2), "f"(t3)
-      );
-
-      // --- Second m16n8k16 replacement (uses B[2], B[3]) ---
-       // First m16n8k8 step (K=0..7)
-      asm volatile(
+          "{%4, %5, %6, %7}, {%8, %9}, {%14}, {%20, %21, %22, %23};\n"
           "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
-          "{%0, %1, %2, %3}," // Temporaries
-          "{%4, %5},"          // A[0], A[1]
-          "{%6},"              // B[2]
-          "{%7, %8, %9, %10};" // C[4], C[5], C[6], C[7] initial
-          : "=f"(t0), "=f"(t1), "=f"(t2), "=f"(t3)
-          : "r"(A[0]), "r"(A[1]), "r"(B[2]),
-            "f"(C[4]), "f"(C[5]), "f"(C[6]), "f"(C[7])
-      );
-      // Second m16n8k8 step (K=8..15), accumulating into temps
-      asm volatile(
+          "{%16, %17, %18, %19}, {%10, %11}, {%13}, {%0, %1, %2, %3};\n"
           "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
-          "{%0, %1, %2, %3}," // C[4], C[5], C[6], C[7] final
-          "{%4, %5},"          // A[2], A[3]
-          "{%6},"              // B[3]
-          "{%7, %8, %9, %10};" // Temporaries from previous step
-          : "=f"(C[4]), "=f"(C[5]), "=f"(C[6]), "=f"(C[7])
-          : "r"(A[2]), "r"(A[3]), "r"(B[3]),
-            "f"(t0), "f"(t1), "f"(t2), "f"(t3)
+          "{%20, %21, %22, %23}, {%10, %11}, {%15}, {%4, %5, %6, %7};\n"
+          "}\n"
+          : "=&f"(t0), "=&f"(t1), "=&f"(t2), "=&f"(t3),
+            "=&f"(t4), "=&f"(t5), "=&f"(t6), "=&f"(t7),
+            "+r"(A[0]), "+r"(A[1]), "+r"(A[2]), "+r"(A[3]),
+            "+r"(B[0]), "+r"(B[1]), "+r"(B[2]), "+r"(B[3]),
+            "+f"(C[0]), "+f"(C[1]), "+f"(C[2]), "+f"(C[3]),
+            "+f"(C[4]), "+f"(C[5]), "+f"(C[6]), "+f"(C[7])
       );
   }
   else if constexpr (mma_mode == MMAMode::kInit)
   {
-      // --- First m16n8k16 replacement (uses B[0], B[1]) ---
-      // First m16n8k8 step (K=0..7)
       asm volatile(
+          "{\n"
           "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
-          "{%0, %1, %2, %3}," // Temporaries
-          "{%4, %5},"          // A[0], A[1]
-          "{%6},"              // B[0]
-          "{%7, %8, %9, %10};" // Zero initializers
-          : "=f"(t0), "=f"(t1), "=f"(t2), "=f"(t3)
-          : "r"(A[0]), "r"(A[1]), "r"(B[0]),
-            "f"(0.f), "f"(0.f), "f"(0.f), "f"(0.f)
-      );
-      // Second m16n8k8 step (K=8..15), accumulating into temps
-      asm volatile(
+          "{%0, %1, %2, %3}, {%8, %9}, {%12}, {0.0, 0.0, 0.0, 0.0};\n"
           "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
-          "{%0, %1, %2, %3}," // C[0], C[1], C[2], C[3] final
-          "{%4, %5},"          // A[2], A[3]
-          "{%6},"              // B[1]
-          "{%7, %8, %9, %10};" // Temporaries from previous step
-          : "=f"(C[0]), "=f"(C[1]), "=f"(C[2]), "=f"(C[3])
-          : "r"(A[2]), "r"(A[3]), "r"(B[1]),
-            "f"(t0), "f"(t1), "f"(t2), "f"(t3)
-      );
-
-      // --- Second m16n8k16 replacement (uses B[2], B[3]) ---
-       // First m16n8k8 step (K=0..7)
-      asm volatile(
+          "{%4, %5, %6, %7}, {%8, %9}, {%14}, {0.0, 0.0, 0.0, 0.0};\n"
           "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
-          "{%0, %1, %2, %3}," // Temporaries
-          "{%4, %5},"          // A[0], A[1]
-          "{%6},"              // B[2]
-          "{%7, %8, %9, %10};" // Zero initializers
-          : "=f"(t0), "=f"(t1), "=f"(t2), "=f"(t3)
-          : "r"(A[0]), "r"(A[1]), "r"(B[2]),
-            "f"(0.f), "f"(0.f), "f"(0.f), "f"(0.f)
-      );
-      // Second m16n8k8 step (K=8..15), accumulating into temps
-      asm volatile(
+          "{%16, %17, %18, %19}, {%10, %11}, {%13}, {%0, %1, %2, %3};\n"
           "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
-          "{%0, %1, %2, %3}," // C[4], C[5], C[6], C[7] final
-          "{%4, %5},"          // A[2], A[3]
-          "{%6},"              // B[3]
-          "{%7, %8, %9, %10};" // Temporaries from previous step
-          : "=f"(C[4]), "=f"(C[5]), "=f"(C[6]), "=f"(C[7])
-          : "r"(A[2]), "r"(A[3]), "r"(B[3]),
-            "f"(t0), "f"(t1), "f"(t2), "f"(t3)
+          "{%20, %21, %22, %23}, {%10, %11}, {%15}, {%4, %5, %6, %7};\n"
+          "}\n"
+          : "=&f"(t0), "=&f"(t1), "=&f"(t2), "=&f"(t3),
+            "=&f"(t4), "=&f"(t5), "=&f"(t6), "=&f"(t7),
+            "+r"(A[0]), "+r"(A[1]), "+r"(A[2]), "+r"(A[3]),
+            "+r"(B[0]), "+r"(B[1]), "+r"(B[2]), "+r"(B[3]),
+            "=f"(C[0]), "=f"(C[1]), "=f"(C[2]), "=f"(C[3]),
+            "=f"(C[4]), "=f"(C[5]), "=f"(C[6]), "=f"(C[7])
       );
   }
 #endif
@@ -476,39 +390,24 @@ __device__ __forceinline__ void mma_sync_m16n16k16_row_col_f16f16f16(uint32_t* C
   uint32_t c2_in = (mma_mode == MMAMode::kInit) ? 0 : C[2];
   uint32_t c3_in = (mma_mode == MMAMode::kInit) ? 0 : C[3];
 
-  // Fragment mapping:
-  // A: {A[0], A[1]} for k=0..7, {A[2], A[3]} for k=8..15
-  // B: {B[0]} k=0..7,n=0..7 | {B[1]} k=8..15,n=0..7 | {B[2]} k=0..7,n=8..15 | {B[3]} k=8..15,n=8..15
-  // C: {C[0], C[1]} n=0..7 | {C[2], C[3]} n=8..15
-
   asm volatile(
     "{\n"
-    // Allocate 4 temporary registers (.b32) for intermediate f16 pairs
     "  .reg .b32 t0, t1, t2, t3;\n\n"
-
-    // --- Compute first 16x8 tile (C0: n=0..7) ---
-    // 1. First K-half: tmp{0,1} = A[k=0..7] * B[k=0..7, n=0..7] + C_in{0,1}
     "  mma.sync.aligned.m16n8k8.row.col.f16.f16.f16.f16 "
-    "{t0, t1}, {%4, %5}, {%8}, {%12, %13};\n" // Inputs: A[0,1], B[0], C_in[0,1]
-    // 2. Second K-half: C{0,1} = A[k=8..15] * B[k=8..15, n=0..7] + tmp{0,1}
+    "{t0, t1}, {%4, %5}, {%8}, {%12, %13};\n"
     "  mma.sync.aligned.m16n8k8.row.col.f16.f16.f16.f16 "
-    "{%0, %1}, {%6, %7}, {%9}, {t0, t1};\n\n" // Inputs: A[2,3], B[1], tmp[0,1] -> Output: C[0,1]
-
-    // --- Compute second 16x8 tile (C1: n=8..15) ---
-    // 1. First K-half: tmp{2,3} = A[k=0..7] * B[k=0..7, n=8..15] + C_in{2,3}
+    "{t2, t3}, {%4, %5}, {%10}, {%14, %15};\n"
     "  mma.sync.aligned.m16n8k8.row.col.f16.f16.f16.f16 "
-    "{t2, t3}, {%4, %5}, {%10}, {%14, %15};\n" // Inputs: A[0,1], B[2], C_in[2,3]
-    // 2. Second K-half: C{2,3} = A[k=8..15] * B[k=8..15, n=8..15] + tmp{2,3}
+    "{%0, %1}, {%6, %7}, {%9}, {t0, t1};\n\n" 
     "  mma.sync.aligned.m16n8k8.row.col.f16.f16.f16.f16 "
-    "{%2, %3}, {%6, %7}, {%11}, {t2, t3};\n" // Inputs: A[2,3], B[3], tmp[2,3] -> Output: C[2,3]
+    "{%2, %3}, {%6, %7}, {%11}, {t2, t3};\n"
     "}\n"
-    : // Output Constraints: Final accumulator values C[0]..C[3]
+    : 
       "=r"(C[0]), "=r"(C[1]), "=r"(C[2]), "=r"(C[3])
-    : // Input Constraints: A[0]..A[3], B[0]..B[3], initial C_in[0]..C_in[3]
+    : 
       "r"(A[0]), "r"(A[1]), "r"(A[2]), "r"(A[3]),     // %4 , %5 , %6 , %7
       "r"(B[0]), "r"(B[1]), "r"(B[2]), "r"(B[3]),     // %8 , %9 , %10, %11
       "r"(c0_in), "r"(c1_in), "r"(c2_in), "r"(c3_in)  // %12, %13, %14, %15
-    // No explicit clobbers needed for .reg allocated temps
   );
 #endif
 }
@@ -550,78 +449,36 @@ __device__ __forceinline__ void mma_sync_m16n8k32_row_col_s8s8s32(int32_t* C, ui
           "r"(0), "r"(0));
   }
 #else  // MMA_S8S8S32_M16N8K32_ENABLED
+  // SM75 optimization: Merge into one ASM block
+  int32_t t0, t1, t2, t3;
 
-  // Emulate m16n8k32.s8.s8.s32 using four m8n8k16.s8.s8.s32 operations.
-  // SM_75 supports m8n8k16 for s8 inputs.
-  // A[0..3] holds the M=16, K=32 fragment components.
-  // B[0..1] holds the K=32, N=8 fragment components.
-  // C[0..3] holds the M=16, N=8 accumulator components.
-  //   C[0], C[1] -> M=0..7 part
-  //   C[2], C[3] -> M=8..15 part
-
-  int32_t tmp0, tmp1, tmp2, tmp3; // Temporary accumulators for first K-half
-
-  // === K = 0..15 part ===
-
-  // MMA 1: M = 0..7, N = 0..7, K = 0..15
-  // Inputs: A[0], B[0]
-  // Accumulator: C[0], C[1] (or 0 if kInit)
-  // Output: tmp0, tmp1
-  asm volatile(
-      "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 "
-      "{%0, %1}, {%2}, {%3}, {%4, %5};\n"
-      : "=r"(tmp0), "=r"(tmp1)
-      : "r"(A[0]),
-        "r"(B[0]),
-        "r"( (mma_mode == MMAMode::kInit) ? 0 : C[0] ),
-        "r"( (mma_mode == MMAMode::kInit) ? 0 : C[1] )
-  );
-
-  // MMA 2: M = 8..15, N = 0..7, K = 0..15
-  // Inputs: A[1], B[0] (Fixed: Was A[2])
-  // Accumulator: C[2], C[3] (or 0 if kInit)
-  // Output: tmp2, tmp3
-  asm volatile(
-      "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 "
-      "{%0, %1}, {%2}, {%3}, {%4, %5};\n"
-      : "=r"(tmp2), "=r"(tmp3)
-      : "r"(A[1]), // Fixed: Use A[1] for Bottom-Left (M=8..15, K=0..15)
-        "r"(B[0]),
-        "r"( (mma_mode == MMAMode::kInit) ? 0 : C[2] ),
-        "r"( (mma_mode == MMAMode::kInit) ? 0 : C[3] )
-  );
-
-
-  // === K = 16..31 part ===
-  // Accumulate onto results from first K-half (stored in tmp0..3)
-
-  // MMA 3: M = 0..7, N = 0..7, K = 16..31
-  // Inputs: A[2], B[1] (Fixed: Was A[1])
-  // Accumulator: tmp0, tmp1
-  // Output: C[0], C[1]
-  asm volatile(
-      "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 "
-      "{%0, %1}, {%2}, {%3}, {%4, %5};\n"
-      : "=r"(C[0]), "=r"(C[1]) // Write final result directly to C
-      : "r"(A[2]), // Fixed: Use A[2] for Top-Right (M=0..7, K=16..31)
-        "r"(B[1]),
-        "r"(tmp0),  // Accumulate with first K-half result
-        "r"(tmp1)
-  );
-
-  // MMA 4: M = 8..15, N = 0..7, K = 16..31
-  // Inputs: A[3], B[1]
-  // Accumulator: tmp2, tmp3
-  // Output: C[2], C[3]
-  asm volatile(
-      "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 "
-      "{%0, %1}, {%2}, {%3}, {%4, %5};\n"
-      : "=r"(C[2]), "=r"(C[3]) // Write final result directly to C
-      : "r"(A[3]), // Corresponds to M=8..15, K=16..31 part
-        "r"(B[1]),
-        "r"(tmp2),  // Accumulate with first K-half result
-        "r"(tmp3)
-  );
+  if constexpr (mma_mode == MMAMode::kInplaceUpdate) {
+    asm volatile(
+        "{\n"
+        "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%0, %1}, {%8}, {%12}, {%14, %15};\n" // A0, B0 -> t0,t1 (accum C0,C1)
+        "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%2, %3}, {%9}, {%12}, {%16, %17};\n" // A1, B0 -> t2,t3 (accum C2,C3)
+        "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%14, %15}, {%10}, {%13}, {%0, %1};\n" // A2, B1 -> C0,C1 (accum t0,t1)
+        "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%16, %17}, {%11}, {%13}, {%2, %3};\n" // A3, B1 -> C2,C3 (accum t2,t3)
+        "}\n"
+        : "=&r"(t0), "=&r"(t1), "=&r"(t2), "=&r"(t3),
+          "+r"(A[0]), "+r"(A[1]), "+r"(A[2]), "+r"(A[3]), // %8-11
+          "+r"(B[0]), "+r"(B[1]), // %12-13
+          "+r"(C[0]), "+r"(C[1]), "+r"(C[2]), "+r"(C[3]) // %14-17
+    );
+  } else {
+    asm volatile(
+        "{\n"
+        "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%0, %1}, {%8}, {%12}, {0, 0};\n"
+        "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%2, %3}, {%9}, {%12}, {0, 0};\n"
+        "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%14, %15}, {%10}, {%13}, {%0, %1};\n"
+        "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%16, %17}, {%11}, {%13}, {%2, %3};\n"
+        "}\n"
+        : "=&r"(t0), "=&r"(t1), "=&r"(t2), "=&r"(t3),
+          "+r"(A[0]), "+r"(A[1]), "+r"(A[2]), "+r"(A[3]),
+          "+r"(B[0]), "+r"(B[1]),
+          "=r"(C[0]), "=r"(C[1]), "=r"(C[2]), "=r"(C[3])
+    );
+  }
 #endif
 }
 
@@ -680,93 +537,51 @@ __device__ __forceinline__ void mma_sync_m16n16k32_row_col_s8s8s32(int32_t* C, u
           "r"(0), "r"(0));
   }
 #else  // SM_75 fallback path
-  // Emulate m16n16k32 using eight m8n8k16 instructions (4 for spatial tiles x 2 for K dimension)
-  // Corrected Layout mapping:
-  // LDMATRIX.x4 produces [R0, R1, R2, R3].
-  // Assuming LDMATRIX order:
-  // R0: TL (M0-7, K0-15)
-  // R1: BL (M8-15, K0-15)
-  // R2: TR (M0-7, K16-31)
-  // R3: BR (M8-15, K16-31)
-  //
-  // Previous code swapped R1 and R2 usage incorrectly. Fixed below.
+  int32_t t0, t1, t2, t3, t4, t5, t6, t7;
 
-  int32_t c_tmp[8];
-
-  if constexpr (mma_mode == MMAMode::kInit) {
-      #pragma unroll
-      for (int i=0; i<8; ++i) c_tmp[i] = 0;
+  if constexpr (mma_mode == MMAMode::kInplaceUpdate) {
+      asm volatile(
+          "{\n"
+          // K chunk 0 (k=0-15)
+          "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%0, %1}, {%8}, {%12}, {%16, %17};\n" // TL: A0, B0 -> t0,t1 (accum C0,C1)
+          "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%2, %3}, {%9}, {%12}, {%18, %19};\n" // BL: A1, B0 -> t2,t3 (accum C2,C3)
+          "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%4, %5}, {%8}, {%14}, {%20, %21};\n" // TR: A0, B2 -> t4,t5 (accum C4,C5)
+          "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%6, %7}, {%9}, {%14}, {%22, %23};\n" // BR: A1, B2 -> t6,t7 (accum C6,C7)
+          
+          // K chunk 1 (k=16-31)
+          "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%16, %17}, {%10}, {%13}, {%0, %1};\n" // TL: A2, B1 -> C0,C1 (accum t0,t1)
+          "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%18, %19}, {%11}, {%13}, {%2, %3};\n" // BL: A3, B1 -> C2,C3 (accum t2,t3)
+          "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%20, %21}, {%10}, {%15}, {%4, %5};\n" // TR: A2, B3 -> C4,C5 (accum t4,t5)
+          "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%22, %23}, {%11}, {%15}, {%6, %7};\n" // BR: A3, B3 -> C6,C7 (accum t6,t7)
+          "}\n"
+          : "=&r"(t0), "=&r"(t1), "=&r"(t2), "=&r"(t3), "=&r"(t4), "=&r"(t5), "=&r"(t6), "=&r"(t7),
+            "+r"(A[0]), "+r"(A[1]), "+r"(A[2]), "+r"(A[3]), // %8-11
+            "+r"(B[0]), "+r"(B[1]), "+r"(B[2]), "+r"(B[3]), // %12-15
+            "+r"(C[0]), "+r"(C[1]), "+r"(C[2]), "+r"(C[3]), // %16-19
+            "+r"(C[4]), "+r"(C[5]), "+r"(C[6]), "+r"(C[7])  // %20-23
+      );
   } else {
-      #pragma unroll
-      for (int i=0; i<8; ++i) c_tmp[i] = C[i];
+      asm volatile(
+          "{\n"
+          // K chunk 0 (k=0-15)
+          "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%0, %1}, {%8}, {%12}, {0, 0};\n"
+          "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%2, %3}, {%9}, {%12}, {0, 0};\n"
+          "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%4, %5}, {%8}, {%14}, {0, 0};\n"
+          "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%6, %7}, {%9}, {%14}, {0, 0};\n"
+          
+          // K chunk 1 (k=16-31)
+          "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%16, %17}, {%10}, {%13}, {%0, %1};\n"
+          "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%18, %19}, {%11}, {%13}, {%2, %3};\n"
+          "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%20, %21}, {%10}, {%15}, {%4, %5};\n"
+          "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%22, %23}, {%11}, {%15}, {%6, %7};\n"
+          "}\n"
+          : "=&r"(t0), "=&r"(t1), "=&r"(t2), "=&r"(t3), "=&r"(t4), "=&r"(t5), "=&r"(t6), "=&r"(t7),
+            "+r"(A[0]), "+r"(A[1]), "+r"(A[2]), "+r"(A[3]),
+            "+r"(B[0]), "+r"(B[1]), "+r"(B[2]), "+r"(B[3]),
+            "=r"(C[0]), "=r"(C[1]), "=r"(C[2]), "=r"(C[3]),
+            "=r"(C[4]), "=r"(C[5]), "=r"(C[6]), "=r"(C[7])
+      );
   }
-
-  // --- K Chunk 0 (k = 0..15) ---
-  // MMA 1.0: Rows 0-7, Cols 0-7, K 0-15
-  asm volatile(
-      "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 "
-      "{%0,  %1}, {%2}, {%3}, {%4,  %5};\n"
-      : "=r"(c_tmp[0]), "=r"(c_tmp[1])
-      : "r"(A[0]), "r"(B[0]), "r"(c_tmp[0]), "r"(c_tmp[1])
-  );
-  // MMA 2.0: Rows 8-15, Cols 0-7, K 0-15
-  // FIXED: Input A should be A[1] (BL) not A[2]
-  asm volatile(
-      "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 "
-      "{%0,  %1}, {%2}, {%3}, {%4,  %5};\n"
-      : "=r"(c_tmp[2]), "=r"(c_tmp[3])
-      : "r"(A[1]), "r"(B[0]), "r"(c_tmp[2]), "r"(c_tmp[3])
-  );
-  // MMA 3.0: Rows 0-7, Cols 8-15, K 0-15
-  asm volatile(
-      "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 "
-      "{%0,  %1}, {%2}, {%3}, {%4,  %5};\n"
-      : "=r"(c_tmp[4]), "=r"(c_tmp[5])
-      : "r"(A[0]), "r"(B[2]), "r"(c_tmp[4]), "r"(c_tmp[5])
-  );
-  // MMA 4.0: Rows 8-15, Cols 8-15, K 0-15
-  // FIXED: Input A should be A[1] (BL) not A[2]
-  asm volatile(
-      "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 "
-      "{%0,  %1}, {%2}, {%3}, {%4,  %5};\n"
-      : "=r"(c_tmp[6]), "=r"(c_tmp[7])
-      : "r"(A[1]), "r"(B[2]), "r"(c_tmp[6]), "r"(c_tmp[7])
-  );
-
-  // --- K Chunk 1 (k = 16..31) --- Accumulate results
-  // MMA 1.1: Rows 0-7, Cols 0-7, K 16-31
-  // FIXED: Input A should be A[2] (TR) not A[1]
-  asm volatile(
-      "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 "
-      "{%0,  %1}, {%2}, {%3}, {%4,  %5};\n"
-      : "=r"(c_tmp[0]), "=r"(c_tmp[1])
-      : "r"(A[2]), "r"(B[1]), "r"(c_tmp[0]), "r"(c_tmp[1])
-  );
-  // MMA 2.1: Rows 8-15, Cols 0-7, K 16-31
-  asm volatile(
-      "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 "
-      "{%0,  %1}, {%2}, {%3}, {%4,  %5};\n"
-      : "=r"(c_tmp[2]), "=r"(c_tmp[3])
-      : "r"(A[3]), "r"(B[1]), "r"(c_tmp[2]), "r"(c_tmp[3])
-  );
-  // MMA 3.1: Rows 0-7, Cols 8-15, K 16-31
-  // FIXED: Input A should be A[2] (TR) not A[1]
-  asm volatile(
-      "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 "
-      "{%0,  %1}, {%2}, {%3}, {%4,  %5};\n"
-      : "=r"(c_tmp[4]), "=r"(c_tmp[5])
-      : "r"(A[2]), "r"(B[3]), "r"(c_tmp[4]), "r"(c_tmp[5])
-  );
-  // MMA 4.1: Rows 8-15, Cols 8-15, K 16-31
-  asm volatile(
-      "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 "
-      "{%0,  %1}, {%2}, {%3}, {%4,  %5};\n"
-      : "=r"(c_tmp[6]), "=r"(c_tmp[7])
-      : "r"(A[3]), "r"(B[3]), "r"(c_tmp[6]), "r"(c_tmp[7])
-  );
-
-  #pragma unroll
-  for (int i=0; i<8; ++i) C[i] = c_tmp[i];
 #endif
 }
 
@@ -998,24 +813,14 @@ __device__ __forceinline__ void rowsum_f16f16f32(float* d, uint32_t* s) {
   // First half of the input (k=0..7)
   asm volatile(
       "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
-      "{%0,  %2,  %1,  %3},"
-      "{%4,  %5},"
-      "{%6},"
-      "{%7,  0.,  %8,  0.};\n"
-      : "=f"(d[0]), "=f"(d[1]), "=f"(dummy0), "=f"(dummy1)
-      : "r"(s[0]), "r"(s[1]), "r"(1006648320),  // 1006648320 packs two 1.0f in half precision
-        "f"(d[0]), "f"(d[1]));
-
-  // Second half of the input (k=8..15)
-  asm volatile(
+      "{%0,  %2,  %1,  %3}, {%4,  %5}, {%6}, {%7,  0.,  %8,  0.};\n"
       "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
-      "{%0,  %2,  %1,  %3},"
-      "{%4,  %5},"
-      "{%6},"
-      "{%7,  0.,  %8,  0.};\n"
-      : "=f"(d[0]), "=f"(d[1]), "=f"(dummy2), "=f"(dummy3)
-      : "r"(s[2]), "r"(s[3]), "r"(1006648320),  // 1006648320 packs two 1.0f in half precision
-        "f"(d[0]), "f"(d[1]));
+      "{%0,  %2,  %1,  %3}, {%9,  %10}, {%6}, {%0,  0.,  %1,  0.};\n"
+      : "+f"(d[0]), "+f"(d[1]), "=f"(dummy0), "=f"(dummy1)
+      : "r"(s[0]), "r"(s[1]), "r"(1006648320),
+        "f"(d[0]), "f"(d[1]),
+        "r"(s[2]), "r"(s[3])
+  );
 #endif
 }
 

--- a/csrc/mma.cuh
+++ b/csrc/mma.cuh
@@ -115,80 +115,48 @@ __device__ __forceinline__ void ldmatrix_m8n8x4_trans(uint32_t* R, T* smem_ptr) 
 #endif
 }
 
-// =========================================================================================
-// [New Addition] Low-Level Primitives for Software Pipelining (The "Split MMA" Strategy)
-
-// =========================================================================================
-
 /*!
- * \brief [Primitive] Raw m16n8k8 MMA instruction for SM75.
- * This is the atomic unit of computation on Turing.
- * Use this to build pipelined m16n8k16 or m16n16k16 loops.
+ * \brief [SM75 Optimized] Step 0 of m16n8k16 (Computes K=0..7)
+ * Usage: Call this, then issue ldmatrix, then call Step 1.
  */
 template <MMAMode mma_mode = MMAMode::kInplaceUpdate>
-__device__ __forceinline__ void mma_sync_m16n8k8_f16f16f32(float* C, uint32_t* A, uint32_t* B) {
+__device__ __forceinline__ void mma_sync_m16n8k16_f16f16f32_step0(float* C, uint32_t* A, uint32_t* B) {
 #ifdef MMA_F16F16F32_M16N8K8_ENABLED
-  if constexpr (mma_mode == MMAMode::kInplaceUpdate) {
-    asm volatile(
-        "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
-        "{%0,  %1,  %2,  %3},"
-        "{%4,  %5},"
-        "{%6},"
-        "{%0,  %1,  %2,  %3};\n" // Input C is also Output C (Accumulate)
-        : "+f"(C[0]), "+f"(C[1]), "+f"(C[2]), "+f"(C[3])
-        : "r"(A[0]), "r"(A[1]), "r"(B[0])
-    );
-  } else {
-    asm volatile(
-        "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
-        "{%0,  %1,  %2,  %3},"
-        "{%4,  %5},"
-        "{%6},"
-        "{0.0, 0.0, 0.0, 0.0};\n" // Zero initialize
-        : "=f"(C[0]), "=f"(C[1]), "=f"(C[2]), "=f"(C[3])
-        : "r"(A[0]), "r"(A[1]), "r"(B[0])
-    );
+  if constexpr (mma_mode == MMAMode::kInit) {
+    C[0] = 0.0f; C[1] = 0.0f; C[2] = 0.0f; C[3] = 0.0f;
   }
-#else
-  RUNTIME_ASSERT("Unsupported CUDA architecture for mma instruction");
+  asm volatile(
+      "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
+      "{%0,  %1,  %2,  %3}, {%4,  %5}, {%6}, {%0,  %1,  %2,  %3};\n"
+      : "+f"(C[0]), "+f"(C[1]), "+f"(C[2]), "+f"(C[3])
+      : "r"(A[0]), "r"(A[1]), "r"(B[0])
+  );
 #endif
 }
 
 /*!
- * \brief [Primitive] Raw m8n8k16 INT8 MMA instruction for SM75.
- * This is the atomic unit for INT8 on Turing.
+ * \brief [SM75 Optimized] Step 1 of m16n8k16 (Computes K=8..15)
  */
 template <MMAMode mma_mode = MMAMode::kInplaceUpdate>
-__device__ __forceinline__ void mma_sync_m8n8k16_s8s8s32(int32_t* C, uint32_t A, uint32_t B) {
-#ifdef MMA_S8S8S32_M16N8K32_ENABLED
-  // SM80 uses the larger instruction, but if we are manually pipelining on SM75, we fall back here.
-  // Note: On SM80+ you should usually prefer the atomic m16n8k32 unless doing very specific scheduling.
-  // This primitive is specifically for SM75 optimization.
-  if constexpr (mma_mode == MMAMode::kInplaceUpdate) {
-    asm volatile(
-        "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 "
-        "{%0, %1}, {%2}, {%3}, {%0, %1};\n"
-        : "+r"(C[0]), "+r"(C[1])
-        : "r"(A), "r"(B)
-    );
-  } else {
-    asm volatile(
-        "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 "
-        "{%0, %1}, {%2}, {%3}, {0, 0};\n"
-        : "=r"(C[0]), "=r"(C[1])
-        : "r"(A), "r"(B)
-    );
-  }
+__device__ __forceinline__ void mma_sync_m16n8k16_f16f16f32_step1(float* C, uint32_t* A, uint32_t* B) {
+#ifdef MMA_F16F16F32_M16N8K8_ENABLED
+  // Always inplace update on top of step0 result
+  asm volatile(
+      "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
+      "{%0,  %1,  %2,  %3}, {%4,  %5}, {%6}, {%0,  %1,  %2,  %3};\n"
+      : "+f"(C[0]), "+f"(C[1]), "+f"(C[2]), "+f"(C[3])
+      : "r"(A[2]), "r"(A[3]), "r"(B[1]) // Note: Uses A[2/3] and B[1]
+  );
 #endif
 }
 
-// =========================================================================================
-// High-Level Wrappers (Optimized for Atomicity + ILP)
-// If you cannot manually pipeline, use these. They use interleaved assembly to hide latency locally.
-// =========================================================================================
-
 /*!
- * \brief Wrapper of the mma m16n8k16 instruction...
+ * \brief Wrapper of the mma m16n8k16 instruction for row major and column major f16 matrix
+ *   multiplication, accumulated in f32.
+ * \tparam mma_mode The mode of mma instruction, either kInit or kInplaceUpdate
+ * \param C pointer to the accumulator
+ * \param A pointer to the fragment of matrix A
+ * \param B pointer to the fragment of matrix B
  */
 template <MMAMode mma_mode = MMAMode::kInplaceUpdate>
 __device__ __forceinline__ void mma_sync_m16n8k16_row_col_f16f16f32(float* C, uint32_t* A,
@@ -220,46 +188,38 @@ __device__ __forceinline__ void mma_sync_m16n8k16_row_col_f16f16f32(float* C, ui
           "f"(0.f), "f"(0.f));
   }
 #else  // MMA_F16F16F32_M16N8K16_ENABLED
-  // [Optimization] SM75 optimized fallback
-  // Uses a single ASM block to allow the compiler to handle register allocation better.
-  // Interleaves the two K-steps inside the hardware pipeline.
-  float t0, t1, t2, t3;
-  if constexpr (mma_mode == MMAMode::kInplaceUpdate)
-  {
-    asm volatile(
-        "{\n"
-        "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
-        "{%0,  %1,  %2,  %3}, {%8,  %9}, {%12}, {%14, %15, %16, %17};\n"
-        "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
-        "{%4,  %5,  %6,  %7}, {%10, %11}, {%13}, {%0,  %1,  %2,  %3};\n"
-        "}\n"
-        : "=&f"(t0), "=&f"(t1), "=&f"(t2), "=&f"(t3), // Early-clobber temps
-          "=f"(C[0]), "=f"(C[1]), "=f"(C[2]), "=f"(C[3])
-        : "r"(A[0]), "r"(A[1]), "r"(A[2]), "r"(A[3]),
-          "r"(B[0]), "r"(B[1]),
-          "f"(C[0]), "f"(C[1]), "f"(C[2]), "f"(C[3])
-    );
+
+  
+  if constexpr (mma_mode == MMAMode::kInit) {
+     C[0] = 0.0f; C[1] = 0.0f; C[2] = 0.0f; C[3] = 0.0f;
   }
-  else if constexpr (mma_mode == MMAMode::kInit)
-  {
-    asm volatile(
-        "{\n"
-        "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
-        "{%0,  %1,  %2,  %3}, {%8,  %9}, {%12}, {0.0, 0.0, 0.0, 0.0};\n"
-        "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
-        "{%4,  %5,  %6,  %7}, {%10, %11}, {%13}, {%0,  %1,  %2,  %3};\n"
-        "}\n"
-        : "=&f"(t0), "=&f"(t1), "=&f"(t2), "=&f"(t3),
-          "=f"(C[0]), "=f"(C[1]), "=f"(C[2]), "=f"(C[3])
-        : "r"(A[0]), "r"(A[1]), "r"(A[2]), "r"(A[3]),
-          "r"(B[0]), "r"(B[1])
-    );
-  }
+
+  asm volatile(
+      "{\n"
+      // K=0..7: Accumulate directly into C
+      "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
+      "{%0,  %1,  %2,  %3}, {%4,  %5}, {%8}, {%0,  %1,  %2,  %3};\n"
+      
+      // K=8..15: Accumulate directly into C
+      "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
+      "{%0,  %1,  %2,  %3}, {%6,  %7}, {%9}, {%0,  %1,  %2,  %3};\n"
+      "}\n"
+      : "+f"(C[0]), "+f"(C[1]), "+f"(C[2]), "+f"(C[3])
+      : "r"(A[0]), "r"(A[1]), "r"(A[2]), "r"(A[3]), // %4-%7
+        "r"(B[0]), "r"(B[1])                        // %8-%9
+  );
+  
+
 #endif
 }
 
 /*!
- * \brief Wrapper of the mma m16n16k16 instruction...
+ * \brief Wrapper of the mma m16n16k16 instruction for row major and column major f16 matrix
+ *   multiplication, accumulated in f32.
+ * \tparam mma_mode The mode of mma instruction, either kInit or kInplaceUpdate
+ * \param C pointer to the accumulator
+ * \param A pointer to the fragment of matrix A
+ * \param B pointer to the fragment of matrix B
  */
 template <MMAMode mma_mode = MMAMode::kInplaceUpdate>
 __device__ __forceinline__ void mma_sync_m16n16k16_row_col_f16f16f32(float* C, uint32_t* A,
@@ -309,60 +269,46 @@ __device__ __forceinline__ void mma_sync_m16n16k16_row_col_f16f16f32(float* C, u
           "f"(0.f), "f"(0.f));
   }
 #else  // MMA_F16F16F32_M16N8K16_ENABLED
-  // [Optimization] SM75 optimized interleaving.
-  // This breaks the dependency chain by computing independent tiles (Left C0-C3, Right C4-C7)
-  // in an interleaved manner. While one instruction waits for result latency, the other issues.
-  float t0, t1, t2, t3, t4, t5, t6, t7;
 
-  if constexpr (mma_mode == MMAMode::kInplaceUpdate)
-  {
-      asm volatile(
-          "{\n"
+  if constexpr (mma_mode == MMAMode::kInit) {
+      C[0]=0.f; C[1]=0.f; C[2]=0.f; C[3]=0.f;
+      C[4]=0.f; C[5]=0.f; C[6]=0.f; C[7]=0.f;
+  }
 
-          "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
-          "{%0, %1, %2, %3}, {%8, %9}, {%12}, {%16, %17, %18, %19};\n"
-          "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
-          "{%4, %5, %6, %7}, {%8, %9}, {%14}, {%20, %21, %22, %23};\n"
-          "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
-          "{%16, %17, %18, %19}, {%10, %11}, {%13}, {%0, %1, %2, %3};\n"
-          "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
-          "{%20, %21, %22, %23}, {%10, %11}, {%15}, {%4, %5, %6, %7};\n"
-          "}\n"
-          : "=&f"(t0), "=&f"(t1), "=&f"(t2), "=&f"(t3),
-            "=&f"(t4), "=&f"(t5), "=&f"(t6), "=&f"(t7),
-            "+r"(A[0]), "+r"(A[1]), "+r"(A[2]), "+r"(A[3]),
-            "+r"(B[0]), "+r"(B[1]), "+r"(B[2]), "+r"(B[3]),
-            "+f"(C[0]), "+f"(C[1]), "+f"(C[2]), "+f"(C[3]),
-            "+f"(C[4]), "+f"(C[5]), "+f"(C[6]), "+f"(C[7])
-      );
-  }
-  else if constexpr (mma_mode == MMAMode::kInit)
-  {
-      asm volatile(
-          "{\n"
-          "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
-          "{%0, %1, %2, %3}, {%8, %9}, {%12}, {0.0, 0.0, 0.0, 0.0};\n"
-          "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
-          "{%4, %5, %6, %7}, {%8, %9}, {%14}, {0.0, 0.0, 0.0, 0.0};\n"
-          "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
-          "{%16, %17, %18, %19}, {%10, %11}, {%13}, {%0, %1, %2, %3};\n"
-          "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
-          "{%20, %21, %22, %23}, {%10, %11}, {%15}, {%4, %5, %6, %7};\n"
-          "}\n"
-          : "=&f"(t0), "=&f"(t1), "=&f"(t2), "=&f"(t3),
-            "=&f"(t4), "=&f"(t5), "=&f"(t6), "=&f"(t7),
-            "+r"(A[0]), "+r"(A[1]), "+r"(A[2]), "+r"(A[3]),
-            "+r"(B[0]), "+r"(B[1]), "+r"(B[2]), "+r"(B[3]),
-            "=f"(C[0]), "=f"(C[1]), "=f"(C[2]), "=f"(C[3]),
-            "=f"(C[4]), "=f"(C[5]), "=f"(C[6]), "=f"(C[7])
-      );
-  }
+  asm volatile(
+      "{\n"
+      // --- Left Tile (B0, B1) ---
+      // K=0..7
+      "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
+      "{%0, %1, %2, %3}, {%8, %9}, {%12}, {%0, %1, %2, %3};\n"
+      // K=8..15
+      "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
+      "{%0, %1, %2, %3}, {%10, %11}, {%13}, {%0, %1, %2, %3};\n"
+
+      // --- Right Tile (B2, B3) ---
+      // K=0..7
+      "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
+      "{%4, %5, %6, %7}, {%8, %9}, {%14}, {%4, %5, %6, %7};\n"
+      // K=8..15
+      "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
+      "{%4, %5, %6, %7}, {%10, %11}, {%15}, {%4, %5, %6, %7};\n"
+      "}\n"
+      : "+f"(C[0]), "+f"(C[1]), "+f"(C[2]), "+f"(C[3]),
+        "+f"(C[4]), "+f"(C[5]), "+f"(C[6]), "+f"(C[7])
+      : "r"(A[0]), "r"(A[1]), "r"(A[2]), "r"(A[3]), // %8-%11
+        "r"(B[0]), "r"(B[1]), "r"(B[2]), "r"(B[3])  // %12-%15
+  );
+
 #endif
 }
 
 /*!
  * \brief Wrapper of the mma m16n8k16 instruction for row major and column major f16 matrix
  *   multiplication, accumulated in f16.
+ * \tparam mma_mode The mode of mma instruction, either kInit or kInplaceUpdate
+ * \param C pointer to the accumulator
+ * \param A pointer to the fragment of matrix A
+ * \param B pointer to the fragment of matrix B
  */
 template <MMAMode mma_mode = MMAMode::kInplaceUpdate>
 __device__ __forceinline__ void mma_sync_m16n8k16_row_col_f16f16f16(uint32_t* C, uint32_t* A,
@@ -398,6 +344,10 @@ __device__ __forceinline__ void mma_sync_m16n8k16_row_col_f16f16f16(uint32_t* C,
 /*!
  * \brief Wrapper of the mma m16n16k16 instruction for row major and column major f16 matrix
  *   multiplication, accumulated in f16.
+ * \tparam mma_mode The mode of mma instruction, either kInit or kInplaceUpdate
+ * \param C pointer to the accumulator
+ * \param A pointer to the fragment of matrix A
+ * \param B pointer to the fragment of matrix B
  */
 template <MMAMode mma_mode = MMAMode::kInplaceUpdate>
 __device__ __forceinline__ void mma_sync_m16n16k16_row_col_f16f16f16(uint32_t* C, uint32_t* A,
@@ -473,6 +423,10 @@ __device__ __forceinline__ void mma_sync_m16n16k16_row_col_f16f16f16(uint32_t* C
 /*!
  * \brief Wrapper of the mma m16n8k32 instruction for row major and column major int8 matrix
  *   multiplication, accumulated in int32.
+ * \tparam mma_mode The mode of mma instruction, either kInit or kInplaceUpdate
+ * \param C pointer to the accumulator
+ * \param A pointer to the fragment of matrix A
+ * \param B pointer to the fragment of matrix B
  */
 template <MMAMode mma_mode = MMAMode::kInplaceUpdate>
 __device__ __forceinline__ void mma_sync_m16n8k32_row_col_s8s8s32(int32_t* C, uint32_t* A,
@@ -503,45 +457,40 @@ __device__ __forceinline__ void mma_sync_m16n8k32_row_col_s8s8s32(int32_t* C, ui
           "r"(0), "r"(0));
   }
 #else  // MMA_S8S8S32_M16N8K32_ENABLED
-  // [Optimization] SM75 optimized fallback
-  // Merged 4 separate ASM blocks into 1 to allow efficient register allocation
-  // and remove call overheads. This simulates m16n8k32 using m8n8k16 primitives.
-  int32_t t0, t1, t2, t3;
 
-  if constexpr (mma_mode == MMAMode::kInplaceUpdate) {
-    asm volatile(
-        "{\n"
-        "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%0, %1}, {%8}, {%12}, {%14, %15};\n" 
-        "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%2, %3}, {%9}, {%12}, {%16, %17};\n" 
-        "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%14, %15}, {%10}, {%13}, {%0, %1};\n" 
-        "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%16, %17}, {%11}, {%13}, {%2, %3};\n" 
-        "}\n"
-        : "=&r"(t0), "=&r"(t1), "=&r"(t2), "=&r"(t3), // Early clobber temps
-          "+r"(A[0]), "+r"(A[1]), "+r"(A[2]), "+r"(A[3]), // %8-11
-          "+r"(B[0]), "+r"(B[1]), // %12-13
-          "+r"(C[0]), "+r"(C[1]), "+r"(C[2]), "+r"(C[3]) // %14-17
-    );
-  } else {
-    // kInit optimization: Initialize with 0 implicitly
-    asm volatile(
-        "{\n"
-        "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%0, %1}, {%8}, {%12}, {0, 0};\n"
-        "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%2, %3}, {%9}, {%12}, {0, 0};\n"
-        "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%14, %15}, {%10}, {%13}, {%0, %1};\n"
-        "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%16, %17}, {%11}, {%13}, {%2, %3};\n"
-        "}\n"
-        : "=&r"(t0), "=&r"(t1), "=&r"(t2), "=&r"(t3),
-          "+r"(A[0]), "+r"(A[1]), "+r"(A[2]), "+r"(A[3]),
-          "+r"(B[0]), "+r"(B[1]),
-          "=r"(C[0]), "=r"(C[1]), "=r"(C[2]), "=r"(C[3])
-    );
+  if constexpr (mma_mode == MMAMode::kInit) {
+      C[0]=0; C[1]=0; C[2]=0; C[3]=0;
   }
+
+  asm volatile(
+      "{\n"
+      // K Chunk 0 (0-15)
+      // Top-Left: C0,C1 += A0, B0
+      "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%0, %1}, {%4}, {%8}, {%0, %1};\n"
+      // Bottom-Left: C2,C3 += A1, B0
+      "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%2, %3}, {%5}, {%8}, {%2, %3};\n"
+
+      // K Chunk 1 (16-31)
+      // Top-Left: C0,C1 += A2, B1
+      "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%0, %1}, {%6}, {%9}, {%0, %1};\n"
+      // Bottom-Left: C2,C3 += A3, B1
+      "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%2, %3}, {%7}, {%9}, {%2, %3};\n"
+      "}\n"
+      : "+r"(C[0]), "+r"(C[1]), "+r"(C[2]), "+r"(C[3])
+      : "r"(A[0]), "r"(A[1]), "r"(A[2]), "r"(A[3]), // %4-%7
+        "r"(B[0]), "r"(B[1])                        // %8-%9
+  );
+
 #endif
 }
 
 /*!
  * \brief Wrapper of the mma m16n16k32 instruction for row major and column major int8 matrix
  *   multiplication, accumulated in int32.
+ * \tparam mma_mode The mode of mma instruction, either kInit or kInplaceUpdate
+ * \param C pointer to the accumulator
+ * \param A pointer to the fragment of matrix A
+ * \param B pointer to the fragment of matrix B
  */
 template <MMAMode mma_mode = MMAMode::kInplaceUpdate>
 __device__ __forceinline__ void mma_sync_m16n16k32_row_col_s8s8s32(int32_t* C, uint32_t* A,
@@ -590,60 +539,46 @@ __device__ __forceinline__ void mma_sync_m16n16k32_row_col_s8s8s32(int32_t* C, u
           "r"(0), "r"(0));
   }
 #else  // SM_75 fallback path
-  // [Optimization] SM75 optimized fallback
-  // Full interleaved instruction scheduling to maximize ILP.
-  // 4 spatial tiles * 2 K-chunks = 8 instructions fused into one block.
-  int32_t t0, t1, t2, t3, t4, t5, t6, t7;
 
-  if constexpr (mma_mode == MMAMode::kInplaceUpdate) {
-      asm volatile(
-          "{\n"
-          // K chunk 0 (k=0-15)
-          "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%0, %1}, {%8}, {%12}, {%16, %17};\n" // TL: A0, B0 -> t0,t1 (accum C0,C1)
-          "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%2, %3}, {%9}, {%12}, {%18, %19};\n" // BL: A1, B0 -> t2,t3 (accum C2,C3)
-          "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%4, %5}, {%8}, {%14}, {%20, %21};\n" // TR: A0, B2 -> t4,t5 (accum C4,C5)
-          "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%6, %7}, {%9}, {%14}, {%22, %23};\n" // BR: A1, B2 -> t6,t7 (accum C6,C7)
-          
-          // K chunk 1 (k=16-31)
-          "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%16, %17}, {%10}, {%13}, {%0, %1};\n" // TL: A2, B1 -> C0,C1 (accum t0,t1)
-          "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%18, %19}, {%11}, {%13}, {%2, %3};\n" // BL: A3, B1 -> C2,C3 (accum t2,t3)
-          "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%20, %21}, {%10}, {%15}, {%4, %5};\n" // TR: A2, B3 -> C4,C5 (accum t4,t5)
-          "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%22, %23}, {%11}, {%15}, {%6, %7};\n" // BR: A3, B3 -> C6,C7 (accum t6,t7)
-          "}\n"
-          : "=&r"(t0), "=&r"(t1), "=&r"(t2), "=&r"(t3), "=&r"(t4), "=&r"(t5), "=&r"(t6), "=&r"(t7),
-            "+r"(A[0]), "+r"(A[1]), "+r"(A[2]), "+r"(A[3]), // %8-11
-            "+r"(B[0]), "+r"(B[1]), "+r"(B[2]), "+r"(B[3]), // %12-15
-            "+r"(C[0]), "+r"(C[1]), "+r"(C[2]), "+r"(C[3]), // %16-19
-            "+r"(C[4]), "+r"(C[5]), "+r"(C[6]), "+r"(C[7])  // %20-23
-      );
-  } else {
-      asm volatile(
-          "{\n"
-          // K chunk 0 (k=0-15)
-          "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%0, %1}, {%8}, {%12}, {0, 0};\n"
-          "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%2, %3}, {%9}, {%12}, {0, 0};\n"
-          "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%4, %5}, {%8}, {%14}, {0, 0};\n"
-          "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%6, %7}, {%9}, {%14}, {0, 0};\n"
-          
-          // K chunk 1 (k=16-31)
-          "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%16, %17}, {%10}, {%13}, {%0, %1};\n"
-          "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%18, %19}, {%11}, {%13}, {%2, %3};\n"
-          "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%20, %21}, {%10}, {%15}, {%4, %5};\n"
-          "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%22, %23}, {%11}, {%15}, {%6, %7};\n"
-          "}\n"
-          : "=&r"(t0), "=&r"(t1), "=&r"(t2), "=&r"(t3), "=&r"(t4), "=&r"(t5), "=&r"(t6), "=&r"(t7),
-            "+r"(A[0]), "+r"(A[1]), "+r"(A[2]), "+r"(A[3]),
-            "+r"(B[0]), "+r"(B[1]), "+r"(B[2]), "+r"(B[3]),
-            "=r"(C[0]), "=r"(C[1]), "=r"(C[2]), "=r"(C[3]),
-            "=r"(C[4]), "=r"(C[5]), "=r"(C[6]), "=r"(C[7])
-      );
+  if constexpr (mma_mode == MMAMode::kInit) {
+      C[0]=0; C[1]=0; C[2]=0; C[3]=0;
+      C[4]=0; C[5]=0; C[6]=0; C[7]=0;
   }
+
+  asm volatile(
+      "{\n"
+      // --- Left Tile (B0, B1) ---
+      // K Chunk 0 (0-15)
+      "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%0, %1}, {%8}, {%12}, {%0, %1};\n" // TL
+      "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%2, %3}, {%9}, {%12}, {%2, %3};\n" // BL
+      // K Chunk 1 (16-31)
+      "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%0, %1}, {%10}, {%13}, {%0, %1};\n" // TL
+      "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%2, %3}, {%11}, {%13}, {%2, %3};\n" // BL
+
+      // --- Right Tile (B2, B3) ---
+      // K Chunk 0 (0-15)
+      "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%4, %5}, {%8}, {%14}, {%4, %5};\n" // TR
+      "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%6, %7}, {%9}, {%14}, {%6, %7};\n" // BR
+      // K Chunk 1 (16-31)
+      "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%4, %5}, {%10}, {%15}, {%4, %5};\n" // TR
+      "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%6, %7}, {%11}, {%15}, {%6, %7};\n" // BR
+      "}\n"
+      : "+r"(C[0]), "+r"(C[1]), "+r"(C[2]), "+r"(C[3]),
+        "+r"(C[4]), "+r"(C[5]), "+r"(C[6]), "+r"(C[7])
+      : "r"(A[0]), "r"(A[1]), "r"(A[2]), "r"(A[3]), // %8-%11
+        "r"(B[0]), "r"(B[1]), "r"(B[2]), "r"(B[3])  // %12-%15
+  );
+
 #endif
 }
 
 /*!
  * \brief Wrapper of the mma m16n8k32 instruction for row major and column major int4 matrix
  *   multiplication, accumulated in int32.
+ * \tparam mma_mode The mode of mma instruction, either kInit or kInplaceUpdate
+ * \param C pointer to the accumulator
+ * \param A pointer to the fragment of matrix A
+ * \param B pointer to the fragment of matrix B
  */
 template <MMAMode mma_mode = MMAMode::kInplaceUpdate>
 __device__ __forceinline__ void mma_sync_m16n8k64_row_col_s4s4s32(int32_t* C, uint32_t* A,
@@ -681,6 +616,10 @@ __device__ __forceinline__ void mma_sync_m16n8k64_row_col_s4s4s32(int32_t* C, ui
 /*!
  * \brief Wrapper of the mma m16n16k64 instruction for row major and column major int4 matrix
  *   multiplication, accumulated in int32.
+ * \tparam mma_mode The mode of mma instruction, either kInit or kInplaceUpdate
+ * \param C pointer to the accumulator
+ * \param A pointer to the fragment of matrix A
+ * \param B pointer to the fragment of matrix B
  */
 template <MMAMode mma_mode = MMAMode::kInplaceUpdate>
 __device__ __forceinline__ void mma_sync_m16n16k64_row_col_s4s4s32(int32_t* C, uint32_t* A,
@@ -736,6 +675,10 @@ __device__ __forceinline__ void mma_sync_m16n16k64_row_col_s4s4s32(int32_t* C, u
 /*!
  * \brief Wrapper of the mma m16n8k32 instruction for row major and column major fp8 e4m3 matrix
  *   multiplication, accumulated in fp32.
+ * \tparam mma_mode The mode of mma instruction, either kInit or kInplaceUpdate
+ * \param C pointer to the accumulator
+ * \param A pointer to the fragment of matrix A
+ * \param B pointer to the fragment of matrix B
  */
 template <MMAMode mma_mode = MMAMode::kInplaceUpdate>
 __device__ __forceinline__ void mma_sync_m16n8k32_row_col_f8f8f32(float* C, uint32_t* A,
@@ -773,6 +716,10 @@ __device__ __forceinline__ void mma_sync_m16n8k32_row_col_f8f8f32(float* C, uint
 /*!
  * \brief Wrapper of the mma m16n16k32 instruction for row major and column major fp8 matrix
  *   multiplication, accumulated in fp32.
+ * \tparam mma_mode The mode of mma instruction, either kInit or kInplaceUpdate
+ * \param C pointer to the accumulator
+ * \param A pointer to the fragment of matrix A
+ * \param B pointer to the fragment of matrix B
  */
 template <MMAMode mma_mode = MMAMode::kInplaceUpdate>
 __device__ __forceinline__ void mma_sync_m16n16k32_row_col_f8f8f32(float* C, uint32_t* A,
@@ -844,22 +791,23 @@ __device__ __forceinline__ void rowsum_f16f16f32(float* d, uint32_t* s) {
       : "r"(s[0]), "r"(s[1]), "r"(s[2]), "r"(s[3]), "r"(1006648320), // 1006648320 packs two 1.0f in half precision
         "r"(1006648320), "f"(d[0]), "f"(d[1]));
 #else
-  // [Optimization] SM75 optimized fallback
-  // Merged two K-steps into one block. Reused output registers as in-out operands (+f)
-  // to reduce register pressure.
-  float dummy0, dummy1;
 
+  
+
+  float zero = 0.0f;
+  
   // First half of the input (k=0..7)
   asm volatile(
       "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
-      "{%0,  %2,  %1,  %3}, {%4,  %5}, {%6}, {%7,  0.,  %8,  0.};\n"
+      "{%0,  _,  %1,  _}, {%2,  %3}, {%4}, {%0,  0.,  %1,  0.};\n"
       "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
-      "{%0,  %2,  %1,  %3}, {%9,  %10}, {%6}, {%0,  0.,  %1,  0.};\n"
-      : "+f"(d[0]), "+f"(d[1]), "=f"(dummy0), "=f"(dummy1)
+      "{%0,  _,  %1,  _}, {%5,  %6}, {%4}, {%0,  0.,  %1,  0.};\n"
+      : "+f"(d[0]), "+f"(d[1])
       : "r"(s[0]), "r"(s[1]), "r"(1006648320),
-        "f"(d[0]), "f"(d[1]),
         "r"(s[2]), "r"(s[3])
   );
+  
+
 #endif
 }
 

--- a/csrc/mma.cuh
+++ b/csrc/mma.cuh
@@ -115,13 +115,80 @@ __device__ __forceinline__ void ldmatrix_m8n8x4_trans(uint32_t* R, T* smem_ptr) 
 #endif
 }
 
+// =========================================================================================
+// [New Addition] Low-Level Primitives for Software Pipelining (The "Split MMA" Strategy)
+
+// =========================================================================================
+
 /*!
- * \brief Wrapper of the mma m16n8k16 instruction for row major and column major f16 matrix
- *   multiplication, accumulated in f32.
- * \tparam mma_mode The mode of mma instruction, either kInit or kInplaceUpdate
- * \param C pointer to the accumulator
- * \param A pointer to the fragment of matrix A
- * \param B pointer to the fragment of matrix B
+ * \brief [Primitive] Raw m16n8k8 MMA instruction for SM75.
+ * This is the atomic unit of computation on Turing.
+ * Use this to build pipelined m16n8k16 or m16n16k16 loops.
+ */
+template <MMAMode mma_mode = MMAMode::kInplaceUpdate>
+__device__ __forceinline__ void mma_sync_m16n8k8_f16f16f32(float* C, uint32_t* A, uint32_t* B) {
+#ifdef MMA_F16F16F32_M16N8K8_ENABLED
+  if constexpr (mma_mode == MMAMode::kInplaceUpdate) {
+    asm volatile(
+        "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
+        "{%0,  %1,  %2,  %3},"
+        "{%4,  %5},"
+        "{%6},"
+        "{%0,  %1,  %2,  %3};\n" // Input C is also Output C (Accumulate)
+        : "+f"(C[0]), "+f"(C[1]), "+f"(C[2]), "+f"(C[3])
+        : "r"(A[0]), "r"(A[1]), "r"(B[0])
+    );
+  } else {
+    asm volatile(
+        "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
+        "{%0,  %1,  %2,  %3},"
+        "{%4,  %5},"
+        "{%6},"
+        "{0.0, 0.0, 0.0, 0.0};\n" // Zero initialize
+        : "=f"(C[0]), "=f"(C[1]), "=f"(C[2]), "=f"(C[3])
+        : "r"(A[0]), "r"(A[1]), "r"(B[0])
+    );
+  }
+#else
+  RUNTIME_ASSERT("Unsupported CUDA architecture for mma instruction");
+#endif
+}
+
+/*!
+ * \brief [Primitive] Raw m8n8k16 INT8 MMA instruction for SM75.
+ * This is the atomic unit for INT8 on Turing.
+ */
+template <MMAMode mma_mode = MMAMode::kInplaceUpdate>
+__device__ __forceinline__ void mma_sync_m8n8k16_s8s8s32(int32_t* C, uint32_t A, uint32_t B) {
+#ifdef MMA_S8S8S32_M16N8K32_ENABLED
+  // SM80 uses the larger instruction, but if we are manually pipelining on SM75, we fall back here.
+  // Note: On SM80+ you should usually prefer the atomic m16n8k32 unless doing very specific scheduling.
+  // This primitive is specifically for SM75 optimization.
+  if constexpr (mma_mode == MMAMode::kInplaceUpdate) {
+    asm volatile(
+        "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 "
+        "{%0, %1}, {%2}, {%3}, {%0, %1};\n"
+        : "+r"(C[0]), "+r"(C[1])
+        : "r"(A), "r"(B)
+    );
+  } else {
+    asm volatile(
+        "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 "
+        "{%0, %1}, {%2}, {%3}, {0, 0};\n"
+        : "=r"(C[0]), "=r"(C[1])
+        : "r"(A), "r"(B)
+    );
+  }
+#endif
+}
+
+// =========================================================================================
+// High-Level Wrappers (Optimized for Atomicity + ILP)
+// If you cannot manually pipeline, use these. They use interleaved assembly to hide latency locally.
+// =========================================================================================
+
+/*!
+ * \brief Wrapper of the mma m16n8k16 instruction...
  */
 template <MMAMode mma_mode = MMAMode::kInplaceUpdate>
 __device__ __forceinline__ void mma_sync_m16n8k16_row_col_f16f16f32(float* C, uint32_t* A,
@@ -153,8 +220,9 @@ __device__ __forceinline__ void mma_sync_m16n8k16_row_col_f16f16f32(float* C, ui
           "f"(0.f), "f"(0.f));
   }
 #else  // MMA_F16F16F32_M16N8K16_ENABLED
-  // SM75 optimization: Use single ASM block to allow ILP between the two MMA instructions.
-  // Although K-split implies dependency, keeping them in one block helps register allocation.
+  // [Optimization] SM75 optimized fallback
+  // Uses a single ASM block to allow the compiler to handle register allocation better.
+  // Interleaves the two K-steps inside the hardware pipeline.
   float t0, t1, t2, t3;
   if constexpr (mma_mode == MMAMode::kInplaceUpdate)
   {
@@ -165,7 +233,7 @@ __device__ __forceinline__ void mma_sync_m16n8k16_row_col_f16f16f32(float* C, ui
         "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
         "{%4,  %5,  %6,  %7}, {%10, %11}, {%13}, {%0,  %1,  %2,  %3};\n"
         "}\n"
-        : "=&f"(t0), "=&f"(t1), "=&f"(t2), "=&f"(t3),
+        : "=&f"(t0), "=&f"(t1), "=&f"(t2), "=&f"(t3), // Early-clobber temps
           "=f"(C[0]), "=f"(C[1]), "=f"(C[2]), "=f"(C[3])
         : "r"(A[0]), "r"(A[1]), "r"(A[2]), "r"(A[3]),
           "r"(B[0]), "r"(B[1]),
@@ -191,12 +259,7 @@ __device__ __forceinline__ void mma_sync_m16n8k16_row_col_f16f16f32(float* C, ui
 }
 
 /*!
- * \brief Wrapper of the mma m16n16k16 instruction for row major and column major f16 matrix
- *   multiplication, accumulated in f32.
- * \tparam mma_mode The mode of mma instruction, either kInit or kInplaceUpdate
- * \param C pointer to the accumulator
- * \param A pointer to the fragment of matrix A
- * \param B pointer to the fragment of matrix B
+ * \brief Wrapper of the mma m16n16k16 instruction...
  */
 template <MMAMode mma_mode = MMAMode::kInplaceUpdate>
 __device__ __forceinline__ void mma_sync_m16n16k16_row_col_f16f16f32(float* C, uint32_t* A,
@@ -246,13 +309,16 @@ __device__ __forceinline__ void mma_sync_m16n16k16_row_col_f16f16f32(float* C, u
           "f"(0.f), "f"(0.f));
   }
 #else  // MMA_F16F16F32_M16N8K16_ENABLED
-  // SM75 optimization: Interleave Left and Right halves calculations to hide latency.
+  // [Optimization] SM75 optimized interleaving.
+  // This breaks the dependency chain by computing independent tiles (Left C0-C3, Right C4-C7)
+  // in an interleaved manner. While one instruction waits for result latency, the other issues.
   float t0, t1, t2, t3, t4, t5, t6, t7;
 
   if constexpr (mma_mode == MMAMode::kInplaceUpdate)
   {
       asm volatile(
           "{\n"
+
           "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
           "{%0, %1, %2, %3}, {%8, %9}, {%12}, {%16, %17, %18, %19};\n"
           "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
@@ -297,10 +363,6 @@ __device__ __forceinline__ void mma_sync_m16n16k16_row_col_f16f16f32(float* C, u
 /*!
  * \brief Wrapper of the mma m16n8k16 instruction for row major and column major f16 matrix
  *   multiplication, accumulated in f16.
- * \tparam mma_mode The mode of mma instruction, either kInit or kInplaceUpdate
- * \param C pointer to the accumulator
- * \param A pointer to the fragment of matrix A
- * \param B pointer to the fragment of matrix B
  */
 template <MMAMode mma_mode = MMAMode::kInplaceUpdate>
 __device__ __forceinline__ void mma_sync_m16n8k16_row_col_f16f16f16(uint32_t* C, uint32_t* A,
@@ -336,10 +398,6 @@ __device__ __forceinline__ void mma_sync_m16n8k16_row_col_f16f16f16(uint32_t* C,
 /*!
  * \brief Wrapper of the mma m16n16k16 instruction for row major and column major f16 matrix
  *   multiplication, accumulated in f16.
- * \tparam mma_mode The mode of mma instruction, either kInit or kInplaceUpdate
- * \param C pointer to the accumulator
- * \param A pointer to the fragment of matrix A
- * \param B pointer to the fragment of matrix B
  */
 template <MMAMode mma_mode = MMAMode::kInplaceUpdate>
 __device__ __forceinline__ void mma_sync_m16n16k16_row_col_f16f16f16(uint32_t* C, uint32_t* A,
@@ -415,10 +473,6 @@ __device__ __forceinline__ void mma_sync_m16n16k16_row_col_f16f16f16(uint32_t* C
 /*!
  * \brief Wrapper of the mma m16n8k32 instruction for row major and column major int8 matrix
  *   multiplication, accumulated in int32.
- * \tparam mma_mode The mode of mma instruction, either kInit or kInplaceUpdate
- * \param C pointer to the accumulator
- * \param A pointer to the fragment of matrix A
- * \param B pointer to the fragment of matrix B
  */
 template <MMAMode mma_mode = MMAMode::kInplaceUpdate>
 __device__ __forceinline__ void mma_sync_m16n8k32_row_col_s8s8s32(int32_t* C, uint32_t* A,
@@ -449,23 +503,26 @@ __device__ __forceinline__ void mma_sync_m16n8k32_row_col_s8s8s32(int32_t* C, ui
           "r"(0), "r"(0));
   }
 #else  // MMA_S8S8S32_M16N8K32_ENABLED
-  // SM75 optimization: Merge into one ASM block
+  // [Optimization] SM75 optimized fallback
+  // Merged 4 separate ASM blocks into 1 to allow efficient register allocation
+  // and remove call overheads. This simulates m16n8k32 using m8n8k16 primitives.
   int32_t t0, t1, t2, t3;
 
   if constexpr (mma_mode == MMAMode::kInplaceUpdate) {
     asm volatile(
         "{\n"
-        "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%0, %1}, {%8}, {%12}, {%14, %15};\n" // A0, B0 -> t0,t1 (accum C0,C1)
-        "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%2, %3}, {%9}, {%12}, {%16, %17};\n" // A1, B0 -> t2,t3 (accum C2,C3)
-        "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%14, %15}, {%10}, {%13}, {%0, %1};\n" // A2, B1 -> C0,C1 (accum t0,t1)
-        "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%16, %17}, {%11}, {%13}, {%2, %3};\n" // A3, B1 -> C2,C3 (accum t2,t3)
+        "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%0, %1}, {%8}, {%12}, {%14, %15};\n" 
+        "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%2, %3}, {%9}, {%12}, {%16, %17};\n" 
+        "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%14, %15}, {%10}, {%13}, {%0, %1};\n" 
+        "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%16, %17}, {%11}, {%13}, {%2, %3};\n" 
         "}\n"
-        : "=&r"(t0), "=&r"(t1), "=&r"(t2), "=&r"(t3),
+        : "=&r"(t0), "=&r"(t1), "=&r"(t2), "=&r"(t3), // Early clobber temps
           "+r"(A[0]), "+r"(A[1]), "+r"(A[2]), "+r"(A[3]), // %8-11
           "+r"(B[0]), "+r"(B[1]), // %12-13
           "+r"(C[0]), "+r"(C[1]), "+r"(C[2]), "+r"(C[3]) // %14-17
     );
   } else {
+    // kInit optimization: Initialize with 0 implicitly
     asm volatile(
         "{\n"
         "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32 {%0, %1}, {%8}, {%12}, {0, 0};\n"
@@ -485,10 +542,6 @@ __device__ __forceinline__ void mma_sync_m16n8k32_row_col_s8s8s32(int32_t* C, ui
 /*!
  * \brief Wrapper of the mma m16n16k32 instruction for row major and column major int8 matrix
  *   multiplication, accumulated in int32.
- * \tparam mma_mode The mode of mma instruction, either kInit or kInplaceUpdate
- * \param C pointer to the accumulator
- * \param A pointer to the fragment of matrix A
- * \param B pointer to the fragment of matrix B
  */
 template <MMAMode mma_mode = MMAMode::kInplaceUpdate>
 __device__ __forceinline__ void mma_sync_m16n16k32_row_col_s8s8s32(int32_t* C, uint32_t* A,
@@ -537,6 +590,9 @@ __device__ __forceinline__ void mma_sync_m16n16k32_row_col_s8s8s32(int32_t* C, u
           "r"(0), "r"(0));
   }
 #else  // SM_75 fallback path
+  // [Optimization] SM75 optimized fallback
+  // Full interleaved instruction scheduling to maximize ILP.
+  // 4 spatial tiles * 2 K-chunks = 8 instructions fused into one block.
   int32_t t0, t1, t2, t3, t4, t5, t6, t7;
 
   if constexpr (mma_mode == MMAMode::kInplaceUpdate) {
@@ -588,10 +644,6 @@ __device__ __forceinline__ void mma_sync_m16n16k32_row_col_s8s8s32(int32_t* C, u
 /*!
  * \brief Wrapper of the mma m16n8k32 instruction for row major and column major int4 matrix
  *   multiplication, accumulated in int32.
- * \tparam mma_mode The mode of mma instruction, either kInit or kInplaceUpdate
- * \param C pointer to the accumulator
- * \param A pointer to the fragment of matrix A
- * \param B pointer to the fragment of matrix B
  */
 template <MMAMode mma_mode = MMAMode::kInplaceUpdate>
 __device__ __forceinline__ void mma_sync_m16n8k64_row_col_s4s4s32(int32_t* C, uint32_t* A,
@@ -629,10 +681,6 @@ __device__ __forceinline__ void mma_sync_m16n8k64_row_col_s4s4s32(int32_t* C, ui
 /*!
  * \brief Wrapper of the mma m16n16k64 instruction for row major and column major int4 matrix
  *   multiplication, accumulated in int32.
- * \tparam mma_mode The mode of mma instruction, either kInit or kInplaceUpdate
- * \param C pointer to the accumulator
- * \param A pointer to the fragment of matrix A
- * \param B pointer to the fragment of matrix B
  */
 template <MMAMode mma_mode = MMAMode::kInplaceUpdate>
 __device__ __forceinline__ void mma_sync_m16n16k64_row_col_s4s4s32(int32_t* C, uint32_t* A,
@@ -688,10 +736,6 @@ __device__ __forceinline__ void mma_sync_m16n16k64_row_col_s4s4s32(int32_t* C, u
 /*!
  * \brief Wrapper of the mma m16n8k32 instruction for row major and column major fp8 e4m3 matrix
  *   multiplication, accumulated in fp32.
- * \tparam mma_mode The mode of mma instruction, either kInit or kInplaceUpdate
- * \param C pointer to the accumulator
- * \param A pointer to the fragment of matrix A
- * \param B pointer to the fragment of matrix B
  */
 template <MMAMode mma_mode = MMAMode::kInplaceUpdate>
 __device__ __forceinline__ void mma_sync_m16n8k32_row_col_f8f8f32(float* C, uint32_t* A,
@@ -729,10 +773,6 @@ __device__ __forceinline__ void mma_sync_m16n8k32_row_col_f8f8f32(float* C, uint
 /*!
  * \brief Wrapper of the mma m16n16k32 instruction for row major and column major fp8 matrix
  *   multiplication, accumulated in fp32.
- * \tparam mma_mode The mode of mma instruction, either kInit or kInplaceUpdate
- * \param C pointer to the accumulator
- * \param A pointer to the fragment of matrix A
- * \param B pointer to the fragment of matrix B
  */
 template <MMAMode mma_mode = MMAMode::kInplaceUpdate>
 __device__ __forceinline__ void mma_sync_m16n16k32_row_col_f8f8f32(float* C, uint32_t* A,
@@ -804,11 +844,10 @@ __device__ __forceinline__ void rowsum_f16f16f32(float* d, uint32_t* s) {
       : "r"(s[0]), "r"(s[1]), "r"(s[2]), "r"(s[3]), "r"(1006648320), // 1006648320 packs two 1.0f in half precision
         "r"(1006648320), "f"(d[0]), "f"(d[1]));
 #else
-  // SM75 fallback using m16n8k8 instruction for k8 instead of k16
-  // We need to do the same operation in two parts
-  
-  // Use dummy registers for unused outputs to avoid using '_' with +f constraint
-  float dummy0, dummy1, dummy2, dummy3;
+  // [Optimization] SM75 optimized fallback
+  // Merged two K-steps into one block. Reused output registers as in-out operands (+f)
+  // to reduce register pressure.
+  float dummy0, dummy1;
 
   // First half of the input (k=0..7)
   asm volatile(

--- a/sageattention/core.py
+++ b/sageattention/core.py
@@ -376,8 +376,12 @@ def sageattn_varlen(
     assert q.stride(-1) == 1 and k.stride(-1) == 1 and v.stride(-1) == 1, "Last dim of qkv must be contiguous."
     assert cu_seqlens_q.is_contiguous() and cu_seqlens_k.is_contiguous(), "cu_seqlens_q and cu_seqlens_k must be contiguous."
 
+    compute_dtype = dtype
     if dtype == torch.bfloat16 or dtype == torch.float32:
+        q = q.to(torch.float16)
+        k = k.to(torch.float16)
         v = v.to(torch.float16)
+        compute_dtype = torch.float16
 
     if smooth_k:
         km = k.mean(dim=0, keepdim=True) # ! km is calculated on the all the batches. Calculate over each individual sequence requires dedicated kernel.
@@ -389,11 +393,14 @@ def sageattn_varlen(
     q_int8, q_scale, k_int8, k_scale, cu_seqlens_q_scale, cu_seqlens_k_scale = per_block_int8_varlen_triton(q, k, cu_seqlens_q, cu_seqlens_k, max_seqlen_q, max_seqlen_k, sm_scale=sm_scale)
 
     if is_causal:
-        o = attn_true_varlen(q_int8, k_int8, v, cu_seqlens_q, cu_seqlens_k, max_seqlen_q, q_scale, k_scale, cu_seqlens_q_scale, cu_seqlens_k_scale, output_dtype=dtype)
+        o = attn_true_varlen(q_int8, k_int8, v, cu_seqlens_q, cu_seqlens_k, max_seqlen_q, q_scale, k_scale, cu_seqlens_q_scale, cu_seqlens_k_scale, output_dtype=compute_dtype)
     else:
-        o = attn_false_varlen(q_int8, k_int8, v, cu_seqlens_q, cu_seqlens_k, max_seqlen_q, q_scale, k_scale, cu_seqlens_q_scale, cu_seqlens_k_scale, output_dtype=dtype)
+        o = attn_false_varlen(q_int8, k_int8, v, cu_seqlens_q, cu_seqlens_k, max_seqlen_q, q_scale, k_scale, cu_seqlens_q_scale, cu_seqlens_k_scale, output_dtype=compute_dtype)
 
     o = o[..., :head_dim_og]
+    
+    if o.dtype != dtype:
+        o = o.to(dtype)
 
     return o
 
@@ -902,3 +909,5 @@ def sageattn_qk_int8_pv_fp8_cuda_sm90(
         return o, lse / 1.44269504 + lse_correction * sm_scale if smooth_k else lse / 1.44269504
     else:
         return o
+
+


### PR DESCRIPTION
﻿Updates `sageattn_varlen` to strictly handle `bfloat16` and `float32` inputs.